### PR TITLE
Support empty or white space texts for /hangout command, will generate a random-ish slug based on a guid

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -59,6 +59,12 @@ namespace GMeet.Controllers
                 return BadRequest();
             }
 
+            // Allow empty text to generate a random slug based on a guid
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                text = Guid.NewGuid().ToString().Substring(0, 8);
+            }
+
             var matches = Regex.Matches(text, @"<@([^\|>]+)[\|>]");
             string slug;
 


### PR DESCRIPTION
It currently 500s so I figure we can support `/hangout` as a base command by generating a random slug.